### PR TITLE
add support for phone log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arris-tg3442-reboot
 
-Python tool to restart your Arris TG3442* cable modem/router remotely.
+Python tool to restart and retrieve the phone log of your Arris TG3442* cable modem/router remotely.
 
 ## Supported firmware versions
 
@@ -28,6 +28,12 @@ Currently, the following firmware versions are supported:
 
 This will use **default** username, password and router IP.
 Use `--help` to learn how to use non-default values.
+
+### To retrieve phone log
+
+`python3 arris-tg3442-reboot.py phone-log`
+
+Note: phone log isn't persistent and is empty after a restart of the modem
 
 ## Docker
 

--- a/arris-tg3442-reboot.py
+++ b/arris-tg3442-reboot.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     elif userArguments.action == "phone-log":
         print("Retrieving phone log since last reboot")
         log = modem.get_phone_log(session, url)
-        if len(log) == 0 or "PhoneLogRecord" not in log:
+        if "PhoneLogRecord" not in log or len(log["PhoneLogRecord"]) == 0:
             print("No entries found")
         else:
-            print(format_phone_log(modem.get_phone_log(session, url)["PhoneLogRecord"]))
+            print(format_phone_log(log["PhoneLogRecord"]))

--- a/firmware.py
+++ b/firmware.py
@@ -90,6 +90,13 @@ class FirmwareMid2020(Firmware):
         if not response.ok:
             response.raise_for_status()
 
+    def get_phone_log(self, session: Session, url: str):
+        response = session.get(url + "/php/phone_call_log_data.php?_n=73995&{%22PhoneLogRecord%22:{}}")
+        if not response.ok:
+            response.raise_for_status()
+        else:
+            return json.loads(response.content)
+
 
 class FirmwareMid2021(FirmwareMid2020):
     pass


### PR DESCRIPTION
Hi,
i added support for retrieving the phone log. Hope this is useful.

example output:
```
# python arris-tg3442-reboot.py phone-log 
Auto-detected firmware version 01.04.046.07.EURO.PC20
Login successful
Retrieving phone log since last reboot
Missed Call on 2022-01-22 12:47 from 01xxxxxxxxx
Received Call on 2022-01-22 12:53 from 01xxxxxxxxx for 4:47 minutes
```
No phone log found:
```
# python arris-tg3442-reboot.py phone-log 
Auto-detected firmware version 01.04.046.07.EURO.PC20
Login successful
Retrieving phone log
No entries found
```
Output of `--help`
```
usage: arris-tg3442-reboot.py [-h] [-u USERNAME] [-p PASSWORD] [-t URL] [{reboot,phone-log}]

Reboot Arris TG3442* cable router remotely.

positional arguments:
  {reboot,phone-log}    the action to send (default to reboot)

options:
  -h, --help            show this help message and exit
  -u USERNAME, --username USERNAME
                        router login username
  -p PASSWORD, --password PASSWORD
                        router login password
  -t URL, --target URL  router IP address/url (prepended by http)
```
the json response from the modem:
```json
{
    "PhoneLogRecord": [
        {
            "CallType": "Received",
            "Date": "PAGE_CALL_LOG_TABLE_TODAY",
            "Duration": "4:47",
            "ExternalNumber": "01xxxxxxxxx",
            "ParameterIndex": 2,
            "Time": "12:53"
        },
        {
            "CallType": "Missed",
            "Date": "PAGE_CALL_LOG_TABLE_TODAY",
            "Duration": "",
            "ExternalNumber": "01xxxxxxxxx",
            "ParameterIndex": 1,
            "Time": "12:47"
        }
    ]
}
```
